### PR TITLE
feat: add alwaysRequired option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ const config = {
     }
   },
   scalars: {},
+  alwaysRequired: false,
 };
 module.exports = config
 ```
+If the `alwaysRequired` field is `true`, it will always give mock values regardless of the required `!` mark in the schema.
 
 ## Development & Examples
 

--- a/packages/graphql-demeter-core/src/MockServer/models.ts
+++ b/packages/graphql-demeter-core/src/MockServer/models.ts
@@ -49,4 +49,5 @@ export type FakerConfiguratedField =
 export type FakerConfig = {
   objects: Record<string, Record<string, FakerConfiguratedField>> | undefined;
   scalars: Record<string, FakerConfiguratedField> | undefined;
+  alwaysRequired: boolean;
 };

--- a/packages/graphql-demeter-core/src/MockServer/models.ts
+++ b/packages/graphql-demeter-core/src/MockServer/models.ts
@@ -49,5 +49,5 @@ export type FakerConfiguratedField =
 export type FakerConfig = {
   objects: Record<string, Record<string, FakerConfiguratedField>> | undefined;
   scalars: Record<string, FakerConfiguratedField> | undefined;
-  alwaysRequired: boolean;
+  alwaysRequired: boolean | undefined;
 };

--- a/packages/graphql-demeter-core/src/MockServer/models.ts
+++ b/packages/graphql-demeter-core/src/MockServer/models.ts
@@ -49,5 +49,5 @@ export type FakerConfiguratedField =
 export type FakerConfig = {
   objects: Record<string, Record<string, FakerConfiguratedField>> | undefined;
   scalars: Record<string, FakerConfiguratedField> | undefined;
-  alwaysRequired: boolean | undefined;
+  alwaysRequired?: boolean | undefined;
 };

--- a/packages/graphql-demeter-core/src/index.ts
+++ b/packages/graphql-demeter-core/src/index.ts
@@ -37,7 +37,7 @@ export const createFakeResolvers = (schemaString: string, fakerConfig?: FakerCon
   const tree = Parser.parse(schemaString);
   const scalars = tree.nodes.filter((n) => n.data.type === TypeDefinition.ScalarTypeDefinition).map((n) => n.name);
   const enums = tree.nodes.filter((n) => n.data.type === TypeDefinition.EnumTypeDefinition).map((n) => n.name);
-  const alwaysRequired = fakerConfig ? fakerConfig.alwaysRequired : false;
+  const alwaysRequired = fakerConfig?.alwaysRequired || false;
   const resolvers = Object.fromEntries(
     tree.nodes
       .filter((n) => n.data.type === TypeDefinition.ObjectTypeDefinition)

--- a/packages/graphql-demeter/src/CLIClass.ts
+++ b/packages/graphql-demeter/src/CLIClass.ts
@@ -30,6 +30,7 @@ export class CLI {
         `const config = {
   objects: {},
   scalars: {},
+  alwaysRequired: false
 };
 module.exports = config`,
       );

--- a/packages/graphql-demeter/src/CLIClass.ts
+++ b/packages/graphql-demeter/src/CLIClass.ts
@@ -30,7 +30,7 @@ export class CLI {
         `const config = {
   objects: {},
   scalars: {},
-  alwaysRequired: false
+  alwaysRequired: false,
 };
 module.exports = config`,
       );


### PR DESCRIPTION
I really appreciate this useful tool and we are using it in our org. However, we encountered a scenario where we need to mock every field even it's not marked as required. We have a very large schema so manually adding a fake value in the config is not possible. Thus I came up with this solution to add an option in the config that allows switching between always mocking and mock according to the schema. I believe this feature will be helpful to other developers.

I've tested the changes locally, please let me know if you have any suggestions. Thank you.